### PR TITLE
Fix consistency threshold

### DIFF
--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/main/InterSystemSetDifference.scala
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/main/InterSystemSetDifference.scala
@@ -1,13 +1,13 @@
 package cmwell.analytics.main
 
 import cmwell.analytics.data.Spark
+import cmwell.analytics.util.ConsistencyThreshold.defaultConsistencyThreshold
+import cmwell.analytics.util.ISO8601.{instantToMillis, instantToText}
 import cmwell.analytics.util._
 import org.apache.log4j.LogManager
 import org.apache.spark.sql.Dataset
 import org.apache.spark.storage.StorageLevel
 import org.rogach.scallop.{ScallopConf, ScallopOption, ValueConverter, singleArgConverter}
-
-import scala.concurrent.duration.Duration
 
 /**
   * This analysis compares the uuids between two CM-Well sites.
@@ -21,7 +21,7 @@ import scala.concurrent.duration.Duration
   * site2 - site1).
   *
   * The result is filtered to exclude false positives, which are current infotons
-  * (i.e., lastModified > now - currentThreshold) that have not reached consistency yet.
+  * (i.e., lastModified > now - consistencyThreshold) that have not reached consistency yet.
   *
   * The results are written as CSV files. There will be a single CSV file within each result.
   */
@@ -35,7 +35,7 @@ object InterSystemSetDifference {
 
       object Opts extends ScallopConf(args) {
 
-        val durationConverter: ValueConverter[Long] = singleArgConverter[Long](Duration(_).toMillis)
+        private val instantConverter: ValueConverter[Long] = singleArgConverter[Long](instantToMillis)
 
         val site1Data: ScallopOption[String] = opt[String]("site1data", short = '1', descr = "The path to the site1 data {uuid,lastModified,path} in parquet format", required = true)
         val site2Data: ScallopOption[String] = opt[String]("site2data", short = '2', descr = "The path to the site2 data {uuid,lastModified,path} in parquet format", required = true)
@@ -43,7 +43,7 @@ object InterSystemSetDifference {
         val site1Name: ScallopOption[String] = opt[String]("site1name", descr = "The logical name for site1", default = Some("site1"))
         val site2Name: ScallopOption[String] = opt[String]("site2name", descr = "The logical name for site2", default = Some("site2"))
 
-        val currentThreshold: ScallopOption[Long] = opt[Long]("current-threshold", short = 'c', descr = "Filter out any inconsistencies that are more current than this duration (e.g., 24h)", default = Some(Duration("1d").toMillis))(durationConverter)
+        val consistencyThreshold: ScallopOption[Long] = opt[Long]("consistency-threshold", short = 'c', descr = "Ignore any inconsistencies at or after this instant", default = Some(defaultConsistencyThreshold))(instantConverter)
 
         val out: ScallopOption[String] = opt[String]("out", short = 'o', descr = "The directory to save the output to (in csv format)", required = true)
         val shell: ScallopOption[Boolean] = opt[Boolean]("spark-shell", short = 's', descr = "Run a Spark shell", required = false, default = Some(false))
@@ -55,6 +55,8 @@ object InterSystemSetDifference {
         appName = "Compare UUIDs between CM-Well instances",
         sparkShell = Opts.shell()
       ).withSparkSessionDo { implicit spark =>
+
+        logger.info(s"Using a consistency threshold of ${instantToText(Opts.consistencyThreshold())}.")
 
         // Since we will be doing multiple set differences with the same files, do an initial repartition and cache to
         // avoid repeating shuffles. We also want to calculate an ideal partition size to avoid OOM.
@@ -75,10 +77,10 @@ object InterSystemSetDifference {
         val site1 = repartition(site1Raw)
         val site2 = repartition(load(Opts.site2Data()))
 
-        SetDifferenceAndFilter(site1, site2, Opts.currentThreshold(), filterOutMeta = true)
+        SetDifferenceAndFilter(site1, site2, Opts.consistencyThreshold(), filterOutMeta = true)
           .write.csv(Opts.out() + s"/${Opts.site1Name()}-except-${Opts.site2Name()}")
 
-        SetDifferenceAndFilter(site2, site1, Opts.currentThreshold(), filterOutMeta = true)
+        SetDifferenceAndFilter(site2, site1, Opts.consistencyThreshold(), filterOutMeta = true)
           .write.csv(Opts.out() + s"/${Opts.site2Name()}-except-${Opts.site1Name()}")
       }
     }

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/main/SetDifferenceUuids.scala
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/main/SetDifferenceUuids.scala
@@ -1,6 +1,8 @@
 package cmwell.analytics.main
 
 import cmwell.analytics.data.Spark
+import cmwell.analytics.util.ConsistencyThreshold.defaultConsistencyThreshold
+import cmwell.analytics.util.ISO8601.{instantToMillis, instantToText}
 import cmwell.analytics.util.{CmwellConnector, KeyFields, SetDifferenceAndFilter}
 import org.apache.log4j.LogManager
 import org.apache.spark.sql.Dataset
@@ -8,16 +10,13 @@ import org.apache.spark.sql.functions.udf
 import org.apache.spark.storage.StorageLevel
 import org.rogach.scallop.{ScallopConf, ScallopOption, ValueConverter, singleArgConverter}
 
-import scala.concurrent.duration.Duration
-
-
 /**
   * This analysis compares the uuids in the infoton and paths tables (from Cassandra) and the index (from ES),
   * and is intended to the internal consistency of uuids within a single CM-Well instance.
   * The set difference is calculated between each source (infoton, path, index) and in each direction.
   *
   * The result is filtered to exclude false positives, which are current infotons
-  * (i.e., lastModified > now - currentThreshold) that have not reached consistency yet.
+  * (i.e., lastModified > now - consistencyThreshold) that have not reached consistency yet.
   *
   * The results are written as CSV files.
   */
@@ -35,7 +34,7 @@ object SetDifferenceUuids {
 
       object Opts extends ScallopConf(args) {
 
-        val durationConverter: ValueConverter[Long] = singleArgConverter[Long](Duration(_).toMillis)
+        private val instantConverter: ValueConverter[Long] = singleArgConverter[Long](instantToMillis)
 
         val parallelism: ScallopOption[Int] = opt[Int]("parallelism", short = 'p', descr = "The parallelism level", default = Some(defaultParallelism))
 
@@ -43,7 +42,7 @@ object SetDifferenceUuids {
         val index: ScallopOption[String] = opt[String]("index", short = 'x', descr = "The path to the index {uuid,lastModified,path} in parquet format", required = true)
         val path: ScallopOption[String] = opt[String]("path", short = 'h', descr = "The path to the path {uuid,lastModified,path} in parquet format", required = true)
 
-        val currentThreshold: ScallopOption[Long] = opt[Long]("current-threshold", short = 'c', descr = "Filter out any inconsistencies that are more current than this duration (e.g., 24h)", default = Some(Duration("1d").toMillis))(durationConverter)
+        val consistencyThreshold: ScallopOption[Long] = opt[Long]("consistency-threshold", short = 'c', descr = "Ignore any inconsistencies at or after this instant", default = Some(defaultConsistencyThreshold))(instantConverter)
 
         val out: ScallopOption[String] = opt[String]("out", short = 'o', descr = "The directory to save the output to (in csv format)", required = true)
         val shell: ScallopOption[Boolean] = opt[Boolean]("spark-shell", short = 's', descr = "Run a Spark shell", required = false, default = Some(false))
@@ -57,6 +56,8 @@ object SetDifferenceUuids {
         appName = "Set Difference UUIDs infoton/path/index",
         sparkShell = Opts.shell()
       ).withSparkSessionDo { implicit spark =>
+
+        logger.info(s"Using a consistency threshold of ${instantToText(Opts.consistencyThreshold())}.")
 
         import spark.implicits._
 
@@ -99,22 +100,22 @@ object SetDifferenceUuids {
         val index = repartition(loadES(Opts.index()).coalesce(Opts.parallelism() * CmwellConnector.coalesceParallelismMultiplier))
         val path = repartition(load(Opts.path()))
 
-        SetDifferenceAndFilter(infoton, path, Opts.currentThreshold())
+        SetDifferenceAndFilter(infoton, path, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/infoton-except-path")
 
-        SetDifferenceAndFilter(infoton, index, Opts.currentThreshold())
+        SetDifferenceAndFilter(infoton, index, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/infoton-except-index")
 
-        SetDifferenceAndFilter(path, index, Opts.currentThreshold())
+        SetDifferenceAndFilter(path, index, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/path-except-index")
 
-        SetDifferenceAndFilter(path, infoton, Opts.currentThreshold())
+        SetDifferenceAndFilter(path, infoton, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/path-except-infoton")
 
-        SetDifferenceAndFilter(index, infoton, Opts.currentThreshold())
+        SetDifferenceAndFilter(index, infoton, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/index-except-infoton")
 
-        SetDifferenceAndFilter(index, path, Opts.currentThreshold())
+        SetDifferenceAndFilter(index, path, Opts.consistencyThreshold())
           .write.csv(Opts.out() + "/index-except-path")
       }
     }

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/util/ConsistencyThreshold.scala
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/util/ConsistencyThreshold.scala
@@ -1,0 +1,17 @@
+package cmwell.analytics.util
+
+import scala.concurrent.duration.Duration
+
+object ConsistencyThreshold {
+
+  /**
+    * The default consistency threshold for an analysis, if one is not supplied by the caller.y
+    * If the lastModified for an inconsistent infoton falls on or after this time, then it is ignored.
+    * This gives CM-Well some time for an infoton to reach consistency.
+    *
+    * This default should probably not ever be used for analysis where extracts are done and then they are
+    * analyzed, since the extracts are done serially. In this case, the caller should calculate an instant
+    * relative to when the extracts start and pass it as the --consistency-threshold parameter.
+    */
+  def defaultConsistencyThreshold: Long = System.currentTimeMillis - Duration("10 min").toMillis
+}

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/util/ISO8601.scala
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/main/scala/cmwell/analytics/util/ISO8601.scala
@@ -1,0 +1,8 @@
+package cmwell.analytics.util
+
+object ISO8601 {
+
+  def instantToMillis(instant: String): Long = java.time.Instant.parse(instant).toEpochMilli
+
+  def instantToText(instant: Long): String = java.time.Instant.ofEpochMilli(instant).toString
+}

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/find-inter-system-uuid-differences.sh
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/find-inter-system-uuid-differences.sh
@@ -33,7 +33,10 @@ if [ ! -d "${WORKING_DIRECTORY}/${EXTRACT_DIRECTORY_SITE2}" ]; then
   exit 1
 fi
 
-CONSISTENCY_THRESHOLD="1d"
+# We don't have a good way to line up the timelines for the two systems, so the consistency threshold
+# is set to now minus one day. This could be reduced if we know that the extracts were started at the same time
+# and given the length of time it takes to do the extracts.
+CONSISTENCY_THRESHOLD=`date --date="1 day ago" -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 set -e # bail out if any command fails
 
@@ -47,7 +50,7 @@ ${SPARK_HOME}/bin/spark-submit \
  --conf "spark.driver.extraJavaOptions=-XX:+UseG1GC" \
  --master ${SPARK_MASTER} --driver-memory ${SPARK_MEMORY} --conf "spark.local.dir=${SPARK_TMP}" \
  --class cmwell.analytics.main.InterSystemSetDifference "${SPARK_ANALYSIS_JAR}" \
- --current-threshold="${CONSISTENCY_THRESHOLD}" \
+ --consistency-threshold="${CONSISTENCY_THRESHOLD}" \
  --site1data "${WORKING_DIRECTORY}/${EXTRACT_DIRECTORY_SITE1}" \
  --site2data "${WORKING_DIRECTORY}/${EXTRACT_DIRECTORY_SITE2}" \
  --site1name "${SITE1_NAME}" \


### PR DESCRIPTION
Correct implementation of consistency threshold. The previous implementation didn't make sense, and could return false positives when run on a system actively ingesting data.

Add logging to show the consistency threshold used for analysis.

Rename --current-threshold parameter to --consistency-threshold since the parameter's format is changing, and the original name was poorly chosen.