### PR TITLE
Increasing payload limit for _in

### DIFF
--- a/server/cmwell-ws/app/controllers/InputHandler.scala
+++ b/server/cmwell-ws/app/controllers/InputHandler.scala
@@ -256,11 +256,10 @@ class InputHandler @Inject()(ingestPushback: IngestPushback,
                        skipValidation: Boolean = false,
                        isOverwrite: Boolean = false): Future[ParsingResponse] = {
 
-    import java.io.{FileInputStream, InputStream}
     import cmwell.web.ld.service.WriteService._
 
-    def viaTempFile: InputStream = new FileInputStream(req.body.asFile)
-    val inputStream = req.body.asBytes().fold(viaTempFile)(_.iterator.asInputStream)
+    val inputStream = req.body.asBytes().getOrElse(throw new RuntimeException("cant find valid content in body of request")).
+      iterator.asInputStream
 
     val timeContext = req.attrs.get(Attrs.RequestReceivedTimestamp)
 

--- a/server/cmwell-ws/app/controllers/InputHandler.scala
+++ b/server/cmwell-ws/app/controllers/InputHandler.scala
@@ -16,7 +16,6 @@ package controllers
 
 import actions.RequestMonitor
 import akka.stream.Materializer
-import akka.util.ByteString
 import cmwell.domain._
 import cmwell.tracking._
 import cmwell.util.concurrent._
@@ -256,15 +255,12 @@ class InputHandler @Inject()(ingestPushback: IngestPushback,
   private def parseRDF(req: Request[RawBuffer],
                        skipValidation: Boolean = false,
                        isOverwrite: Boolean = false): Future[ParsingResponse] = {
-    import java.io.ByteArrayInputStream
 
+    import java.io.{FileInputStream, InputStream}
     import cmwell.web.ld.service.WriteService._
 
-    val bais = req.body.asBytes() match {
-      //FIXME: quick inefficient hack (there should be a better way to consume body as InputStream)
-      case Some(bs) => new ByteArrayInputStream(bs.toArray[Byte]) //.asByteBuffer.array())
-      case _        => throw new RuntimeException("cant find valid content in body of request")
-    }
+    def viaTempFile: InputStream = new FileInputStream(req.body.asFile)
+    val inputStream = req.body.asBytes().fold(viaTempFile)(_.iterator.asInputStream)
 
     val timeContext = req.attrs.get(Attrs.RequestReceivedTimestamp)
 
@@ -274,7 +270,7 @@ class InputHandler @Inject()(ingestPushback: IngestPushback,
           cmwellRDFHelper,
           crudService,
           authUtils,
-          bais,
+          inputStream,
           Some(List[String](f)),
           req.contentType,
           authUtils.extractTokenFrom(req),
@@ -286,7 +282,7 @@ class InputHandler @Inject()(ingestPushback: IngestPushback,
         handleFormatByContentType(cmwellRDFHelper,
                                   crudService,
                                   authUtils,
-                                  bais,
+                                  inputStream,
                                   req.contentType,
                                   authUtils.extractTokenFrom(req),
                                   skipValidation,

--- a/server/cmwell-ws/src/pack/application.conf
+++ b/server/cmwell-ws/src/pack/application.conf
@@ -10,8 +10,8 @@ play {
 
   http {
     parser {
-      maxDiskBuffer = 1G
-      maxMemoryBuffer = 128M
+      maxDiskBuffer = 512M
+      maxMemoryBuffer = 512M
     }
 
     # Secret key

--- a/server/cmwell-ws/src/pack/application.conf
+++ b/server/cmwell-ws/src/pack/application.conf
@@ -10,8 +10,7 @@ play {
 
   http {
     parser {
-      maxDiskBuffer = 128M
-      # TODO: reduce back to default (100K) after propagating a "stream" instead of Array[Byte] everywhere (e.g. FileInfoton's content)
+      maxDiskBuffer = 1G
       maxMemoryBuffer = 128M
     }
 


### PR DESCRIPTION
We have a use case of a customer who needs to use _replaceGraph_ API for a large graph (payload in NQuads format is  about 314MB); current implementation of user is to break down the post. Doing so can cause data inconsistency, as the new graph should be contained entirely in same POST as the replaceGraph command.

We will ask them to post the entire graph when replacing it, but first we need to increase our limitation.

- Eli && Liel, I'd like both of you to review this one. Thanks.
- Let's think about WS's memory, and the amount of free space in `/tmp`.