### PR TITLE
allow :: operator for system.parent.parent_hierarchy

### DIFF
--- a/server/cmwell-ws/app/wsutil/RawFieldFilter.scala
+++ b/server/cmwell-ws/app/wsutil/RawFieldFilter.scala
@@ -137,7 +137,7 @@ object RawFieldFilter extends PrefixRequirement {
     valueOp match {
       case Equals
           if fieldName.indexOf('$') == 1 ||
-            fieldName.startsWith("system.") ||
+            fieldName.startsWith("system.") && fieldName != "system.parent.parent_hierarchy" ||
             fieldName.startsWith("content.") =>
         SingleFieldFilter(fieldOp, Contains, fieldName, value)
       case _ => SingleFieldFilter(fieldOp, valueOp, fieldName, value)


### PR DESCRIPTION
It was needed for dc-sync with qp to allow filtering only subpath that is not from root.
relates to #1136 