### PR TITLE
Set correct number of partitions on Grid upgrade

### DIFF
--- a/server/cmwell-cons/src/main/scala/Grid.scala
+++ b/server/cmwell-cons/src/main/scala/Grid.scala
@@ -174,7 +174,7 @@ case class Grid(user: String,
         debug = deb,
         hostIp = host,
         minMembers = getMinMembers,
-        numOfPartitions = hosts.size,
+        numOfPartitions = ips.size,
         seeds = getSeedNodes.mkString(","),
         defaultRdfProtocol = defaultRdfProtocol,
         transportAddress = this.getThreesome(ips, host)


### PR DESCRIPTION
When using Grid division, after upgrade, only 1 bg actor would start.
Fixes #1178 