### PR TITLE
STP Quick Fix

### DIFF
--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/Retry.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/Retry.scala
@@ -177,13 +177,20 @@ object Retry extends DataToolsLogging with DataToolsConfig {
           }
           else {
             // server error
-            // special case: sparql-processor //todo: remove this in future
+            // special case: sparql-processor //TODO: remove this in future
 
             e.dataBytes.runFold(ByteString.empty)(_ ++ _).map(_.utf8String).map{ entity=>
               logger.warn(s"[$errorID] server error. Body of response: $entity, headers: ${headersString(h)}")
             }
 
-            if (e.toString contains "Fetching") {
+            // special case: sparql-processor //TODO: remove this in future
+            if (e.toString contains "SpHandler Parsing error") {
+              logger.warn(
+                s"$labelValue will not schedule a retry for the SpHandler Parsing Error"
+              )
+
+              None
+            } else if (e.toString contains "Fetching") {
               logger.warn(
                 s"$labelValue will not schedule a retry on data ${concatByteStrings(data, endl).utf8String}"
               )

--- a/server/cmwell-dc/src/main/scala/cmwell/dc/stream/TsvRetriever.scala
+++ b/server/cmwell-dc/src/main/scala/cmwell/dc/stream/TsvRetriever.scala
@@ -183,9 +183,11 @@ object TsvRetriever extends LazyLogging {
     val (host, port) = hostPort.head -> hostPort.tail.headOption
       .getOrElse("80")
       .toInt
+
     val tsvPoolConfig = ConfigFactory
-      .parseString("akka.http.host-connection-pool.max-connections=1")
+      .parseString("akka.http.host-connection-pool.max-connections=20")
       .withFallback(config)
+
     val tsvConnPool = Http()
       .newHostConnectionPool[TsvRetrieveState](
         host,

--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -2130,7 +2130,7 @@ callback=< [URL] >
 
         val sortBy = getQueryString("sort-by").getOrElse("")
         val rawSortParamsTry = SortByParser.parseFieldSortParams(sortBy)
-        val rawSortParams = rawSortParamsTry.getOrElse(SortParam.empty)
+        val rawSortParams = rawSortParamsTry.getOrElse(RawSortParam.empty)
 
         val withDescendants = queryString.keySet("with-descendants") || queryString.keySet("recursive")
         val withDeleted = queryString.keySet("with-deleted")

--- a/server/cmwell-ws/app/controllers/SpHandler.scala
+++ b/server/cmwell-ws/app/controllers/SpHandler.scala
@@ -89,7 +89,7 @@ class SpHandlerController @Inject()(crudServiceFS: CRUDServiceFS)(implicit ec: E
     import SpHandler._
 
     Try(parse(req)) match {
-      case Failure(_) => Future.successful(wsutil.exceptionToResponse(new IllegalArgumentException("Parsing error")))
+      case Failure(_) => Future.successful(wsutil.exceptionToResponse(new IllegalArgumentException("SpHandler Parsing error")))
       case Success(fun) => {
         val formatByRestOpt = if (formatByRest.nonEmpty) Some(formatByRest) else None
         val rp = RequestParameters(req, formatByRestOpt)


### PR DESCRIPTION
Quick fix for sort by parsing.

SparqlProcessorManager needs a [proper retry](https://github.com/CM-Well/CM-Well/blob/master/server/cmwell-sparql-agent/src/main/scala/cmwell/tools/data/sparql/SparqlProcessorManager.scala#L608) for 400 statuses, because right now retrying 503 with a delay seams to work fine, but 400'ies result in a short-circuit.

I've added a [special case](https://github.com/CM-Well/CM-Well/pull/1303/commits/865e61416b2c6f64c8bdbd9b6d57e7e3a798bf59#diff-e3aab043a3f445ff9ba6a445bcc50908) for that, but that's far from optimal.

Needs refactoring.
