### PR TITLE
BG: fix wrong offset reporting in case of fast writes+retry fixes

### DIFF
--- a/server/cmwell-bg/src/pack/application.conf
+++ b/server/cmwell-bg/src/pack/application.conf
@@ -61,7 +61,7 @@ cmwell {
     safetyNetTime = 1 minute
     restartDelayTime = 30 seconds
     retryDuration = 30.seconds
-    checkParallelism = 1
+    checkParallelism = 5
   }
 }
 

--- a/server/cmwell-bg/src/pack/logback.xml
+++ b/server/cmwell-bg/src/pack/logback.xml
@@ -6,7 +6,7 @@
             <fileNamePattern>logs/application-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -38,7 +38,7 @@
             <fileNamePattern>${application.home:-.}/logs/markedLog-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -70,7 +70,7 @@
             <fileNamePattern>logs/imp-application-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -95,7 +95,7 @@
             <fileNamePattern>logs/indexer-application-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -120,7 +120,7 @@
             <fileNamePattern>logs/es-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -145,7 +145,7 @@
             <fileNamePattern>logs/akka-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -170,7 +170,7 @@
             <fileNamePattern>logs/red-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -195,7 +195,7 @@
             <fileNamePattern>logs/heartbeat-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
@@ -220,7 +220,7 @@
             <fileNamePattern>logs/crawler-log-%d{yyyy-MM-dd, UTC}.%i.gz</fileNamePattern>
             <!-- keep 1 week worth of history (max 20GB) with each file compressed after 100MB -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>7</maxHistory>
+            <maxHistory>21</maxHistory>
             <totalSizeCap>20GB</totalSizeCap>
             <!-- in case of process terminating too early for rollover - do the rollover during start -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>

--- a/server/cmwell-ws/app/BGMonitorActor.scala
+++ b/server/cmwell-ws/app/BGMonitorActor.scala
@@ -178,9 +178,9 @@ class BGMonitorActor(zkServers: String,
                     redSince.putIfAbsent(key, currentTime)
                   case Some(since) if ((currentTime - since) > 15 * 60 * 1000) =>
                     logger.error(
-                      s"BG status for partition ${key} is RED for more than 15 minutes. sending it an exit message"
+                      s"BG status for partition ${key} is RED for more than 15 minutes. (DISABLED - NOT sending it an exit message)"
                     )
-                    Grid.serviceRef(s"BGActor${partitionInfo.partition}") ! ExitWithError
+//                    Grid.serviceRef(s"BGActor${partitionInfo.partition}") ! ExitWithError
                     redSince.replace(key, currentTime)
                   case Some(since) =>
                     logger.warn(


### PR DESCRIPTION
retry fixes:
1. in case of whole bulk exception
2. in case of new fileds creation timeout in ES
3. current=false was sent to ES before the actual infoton was written

Crawler parallelism increased to 5
BGMonitorActor won't kill BG anymore, just monitor
BG logs rolling increase to 3 weeks